### PR TITLE
refactor useFetch with AbortController interface ,  refactored if/else

### DIFF
--- a/src/hooks/useFetch.jsx
+++ b/src/hooks/useFetch.jsx
@@ -1,11 +1,22 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from "react";
 
 export const useFetch = (url) => {
-  const [data, setData] = useState([])
+  const [data, setData] = useState(null);
   useEffect(() => {
-    fetch(url)
-      .then((res) => res.json())
-      .then((data) => setData(data.results))
-  }, [url])
-  return data
-}
+    let mounted = true;
+    const abortController = new AbortController();
+    (async () => {
+      const res = await fetch(url, {
+        signal: abortController.signal,
+      });
+      const data = await res.json();
+      if (mounted) setData(data.result);
+    })();
+    const cleanup = () => {
+      mounted = false;
+      abortController.abort();
+    };
+    return cleanup;
+  }, [url]);
+  return data;
+};

--- a/src/hooks/useGetFormattedPokemon.jsx
+++ b/src/hooks/useGetFormattedPokemon.jsx
@@ -1,55 +1,46 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect } from "react";
 
 export const useGetFormattedPokemon = () => {
-  const ALL_POKEMON_URL = 'https://pokeapi.co/api/v2/pokemon/?limit=905'
-  const POKEMON_IMAGE_URL = 'https://www.serebii.net/pokemongo/pokemon/'
+  const ALL_POKEMON_URL = "https://pokeapi.co/api/v2/pokemon/?limit=905";
+  const POKEMON_IMAGE_URL = "https://www.serebii.net/pokemongo/pokemon/";
 
-  const [pokemons, setPokemons] = useState([])
+  const [pokemons, setPokemons] = useState([]);
 
   const getGeneration = (id) => {
-    if (id >= 1 && id <= 150) {
-      return 1
-    } else if (id >= 152 && id <= 251) {
-      return 2
-    } else if (id >= 252 && id <= 386) {
-      return 3
-    } else if (id >= 387 && id <= 493) {
-      return 4
-    } else if (id >= 494 && id <= 649) {
-      return 5
-    } else if (id >= 650 && id <= 721) {
-      return 6
-    } else if (id >= 722 && id <= 809) {
-      return 7
-    } else if (id >= 810 && id <= 905) {
-      return 8
-    }
-  }
+    if (id >= 1 && id <= 150) return 1;
+    if (id >= 152 && id <= 251) return 2;
+    if (id >= 252 && id <= 386) return 3;
+    if (id >= 387 && id <= 493) return 4;
+    if (id >= 494 && id <= 649) return 5;
+    if (id >= 650 && id <= 721) return 6;
+    if (id >= 722 && id <= 809) return 7;
+    if (id >= 810 && id <= 905) return 8;
+  };
 
   const formatName = (pokemonName) => {
-    return pokemonName.charAt(0).toUpperCase() + pokemonName.slice(1)
-  }
+    return pokemonName.charAt(0).toUpperCase() + pokemonName.slice(1);
+  };
 
   const getFormattedImageUrl = (id) => {
-    const stringId = id.toString()
+    const stringId = id.toString();
 
     return {
       1: `${POKEMON_IMAGE_URL}00${id}.png`,
       2: `${POKEMON_IMAGE_URL}0${id}.png`,
       3: `${POKEMON_IMAGE_URL}${id}.png`,
-    }[stringId.length]
-  }
+    }[stringId.length];
+  };
 
   useEffect(() => {
     const fetchData = async () => {
       const pokemonsFromFirstFetch = (
         await (await fetch(ALL_POKEMON_URL)).json()
-      ).results
+      ).results;
 
       const formattedPokemon = await Promise.all(
         pokemonsFromFirstFetch.map(async (pokemon) => {
-          const pokeInfoFromApi = await (await fetch(pokemon.url)).json()
-          const { name, height, weight, types, id } = pokeInfoFromApi
+          const pokeInfoFromApi = await (await fetch(pokemon.url)).json();
+          const { name, height, weight, types, id } = pokeInfoFromApi;
           return {
             id,
             name: formatName(name),
@@ -58,15 +49,15 @@ export const useGetFormattedPokemon = () => {
             types,
             generation: getGeneration(id),
             imageUrl: getFormattedImageUrl(id),
-          }
+          };
         })
-      )
+      );
 
-      setPokemons(formattedPokemon)
-    }
+      setPokemons(formattedPokemon);
+    };
 
-    fetchData()
-  }, [])
+    fetchData();
+  }, []);
 
-  return pokemons
-}
+  return pokemons;
+};

--- a/src/hooks/useGetPokemonsFromGenerations.tsx
+++ b/src/hooks/useGetPokemonsFromGenerations.tsx
@@ -8,7 +8,6 @@ export const useGetPokemonsFromGenerations = (
 ) => {
   const [filteredPokemons, setFilteredPokemons] = useState<Pokemon[]>([])
 
-
   const getPokemonsFromSelectedGenerations = (
     includedGenerations: (number | false)[]
   ) => {


### PR DESCRIPTION
1 - Refactor useFetch Hook.
It would be better if we can really stop data fetching in the browser. [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) enables

2 - Refactor if - else by Guard clause.
Nested if-else statements can make it unnecessarily complicated to reason about the different executions paths and results of a function. A loss of productivity and the introduction of bugs due to misunderstandings can be the outcome.
A guard clause checks for a condition and returns from the function if the condition is true, potentially doing some computation and returning a result. It makes it easier to reason about the function by ending one execution path early.